### PR TITLE
Add settings.gradle and configure repositories for all projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,4 @@ keystore.properties
 /gradle/wrapper/gradle-wrapper.properties
 /gradlew
 /gradlew.bat
-/settings.gradle
 /app/release

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,14 @@ buildscript {
     }
 }
 
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include ':app'


### PR DESCRIPTION
This is required for building, otherwise it can't load the plugins:

```
$ gradle-7.3.3 tasks

FAILURE: Build failed with an exception.

* Where:
Build file '.../UsbTerminal/app/build.gradle' line: 2

* What went wrong:
Plugin [id: 'com.android.application'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (plugin dependency must include a version number for this source)
```