### PR TITLE
Support the ESP32 USB console

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     // Logging. Latest version here: https://mvnrepository.com/artifact/com.jakewharton.timber/timber
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
-    implementation 'com.github.mik3y:usb-serial-for-android:3.4.4'
+    implementation 'com.github.mik3y:usb-serial-for-android:3.7.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "com.google.truth:truth:1.1"

--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -76,4 +76,8 @@
     <!-- 0x04D8 / 0xFB00, 0xF7EA -->
     <usb-device vendor-id="1240" product-id="64256" />  <!-- BUS_PIRATE_V4 -->
     <usb-device vendor-id="1240" product-id="63466" />  <!-- BUS_PIRATE_V3_CUSTOM -->
+
+    <!-- 20231216: Espressif USB JTAG/serial debug unit -->
+    <!-- 0x303a / 0x1001 -->
+    <usb-device vendor-id="12346" product-id="4097" />
 </resources>


### PR DESCRIPTION
Add the ESP32 USB console device to the device filter and upgrade usb-serial-for-android so that it's auto-detected as CDC/ACM.